### PR TITLE
Add prototype AR tutorial assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # gol
-codex
+
+Ejemplo de asistente de tutoriales con IA y realidad aumentada.
+
+Este repositorio incluye un script (`ar_tutorial.py`) que muestra la imagen de la cámara y superpone instrucciones paso a paso obtenidas mediante la API de OpenAI. Se requiere `opencv-python` y una clave de API válida.
+
+```
+python ar_tutorial.py "Nombre del Programa" --api-key TU_CLAVE
+```
+
+Presiona `n` para el siguiente paso y `q` para salir.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Ejemplo de asistente de tutoriales con IA y realidad aumentada.
 
 Este repositorio incluye un script (`ar_tutorial.py`) que muestra la imagen de la cámara y superpone instrucciones paso a paso obtenidas mediante la API de OpenAI. Se requiere `opencv-python` y una clave de API válida.
 
-Por defecto, el asistente te guía en el uso del editor de nodos de Blender, aunque puedes especificar cualquier otro programa.
+Por defecto, el asistente te guía en el uso del editor de nodos de Blender, aunque puedes especificar cualquier otro programa. También es experto en FL Studio y te puede guiar para crear una canción desde cero.
 
 ```
 python ar_tutorial.py --api-key TU_CLAVE             # Aprende nodos en Blender
+python ar_tutorial.py "FL Studio" --api-key TU_CLAVE             # Crea una canción desde cero
 python ar_tutorial.py "Nombre del Programa" --api-key TU_CLAVE  # Otro software
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ Ejemplo de asistente de tutoriales con IA y realidad aumentada.
 
 Este repositorio incluye un script (`ar_tutorial.py`) que muestra la imagen de la cámara y superpone instrucciones paso a paso obtenidas mediante la API de OpenAI. Se requiere `opencv-python` y una clave de API válida.
 
+Por defecto, el asistente te guía en el uso del editor de nodos de Blender, aunque puedes especificar cualquier otro programa.
+
 ```
-python ar_tutorial.py "Nombre del Programa" --api-key TU_CLAVE
+python ar_tutorial.py --api-key TU_CLAVE             # Aprende nodos en Blender
+python ar_tutorial.py "Nombre del Programa" --api-key TU_CLAVE  # Otro software
 ```
 
 Presiona `n` para el siguiente paso y `q` para salir.

--- a/ar_tutorial.py
+++ b/ar_tutorial.py
@@ -1,3 +1,9 @@
+"""Prototype AR assistant that overlays tutorial steps on a webcam feed.
+
+Por defecto, el asistente explica el editor de nodos de Blender, aunque acepta
+cualquier tema como argumento.
+"""
+
 import cv2
 import openai
 
@@ -24,7 +30,12 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="AR Tutorial Assistant")
-    parser.add_argument("topic", help="Program or topic to learn")
+    parser.add_argument(
+        "topic",
+        nargs="?",
+        default="Blender node editor",
+        help="Program or topic to learn (default: Blender node editor)",
+    )
     parser.add_argument("--api-key", required=True, help="OpenAI API key")
     args = parser.parse_args()
 

--- a/ar_tutorial.py
+++ b/ar_tutorial.py
@@ -1,7 +1,8 @@
 """Prototype AR assistant that overlays tutorial steps on a webcam feed.
 
 Por defecto, el asistente explica el editor de nodos de Blender, aunque acepta
-cualquier tema como argumento.
+cualquier tema como argumento. También es experto en FL Studio y puede guiarte
+para crear una canción desde cero.
 """
 
 import cv2

--- a/ar_tutorial.py
+++ b/ar_tutorial.py
@@ -1,0 +1,66 @@
+import cv2
+import openai
+
+class AITutorialAssistant:
+    """Simple assistant that fetches tutorial steps via the OpenAI API."""
+    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
+        openai.api_key = api_key
+        self.model = model
+
+    def get_step(self, topic: str, step: int) -> str:
+        """Return text for a step-by-step tutorial."""
+        prompt = (
+            f"You are teaching a user how to use {topic}. "
+            f"Provide concise instructions for step {step}."
+        )
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message["content"].strip()
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="AR Tutorial Assistant")
+    parser.add_argument("topic", help="Program or topic to learn")
+    parser.add_argument("--api-key", required=True, help="OpenAI API key")
+    args = parser.parse_args()
+
+    assistant = AITutorialAssistant(api_key=args.api_key)
+    cap = cv2.VideoCapture(0)
+    step = 1
+
+    if not cap.isOpened():
+        raise SystemExit("Could not open webcam")
+
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            instruction = assistant.get_step(args.topic, step)
+            cv2.putText(
+                frame,
+                instruction,
+                (20, 40),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                1.0,
+                (0, 255, 0),
+                2,
+                cv2.LINE_AA,
+            )
+            cv2.imshow("Tutorial", frame)
+            key = cv2.waitKey(1) & 0xFF
+            if key == ord("n"):
+                step += 1
+            elif key == ord("q"):
+                break
+    finally:
+        cap.release()
+        cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ar_tutorial.py` prototype that overlays OpenAI-generated instructions on webcam feed
- update README with usage instructions in Spanish

## Testing
- `python -m py_compile ar_tutorial.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4d972fac83248c42688147100b21