### PR TITLE
Add voice output to AR tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 Ejemplo de asistente de tutoriales con IA y realidad aumentada.
 
-Este repositorio incluye un script (`ar_tutorial.py`) que muestra la imagen de la cámara y superpone instrucciones paso a paso obtenidas mediante la API de OpenAI. Se requiere `opencv-python` y una clave de API válida.
+Este repositorio incluye un script (`ar_tutorial.py`) que muestra la imagen de la cámara y superpone instrucciones paso a paso obtenidas mediante la API de OpenAI. Se requiere `opencv-python`, la librería `openai` y una clave de API válida. La síntesis de voz usa `pyttsx3`, que es opcional si ejecutas el programa con `--mute`.
 
 Por defecto, el asistente te guía en el uso del editor de nodos de Blender, aunque puedes especificar cualquier otro programa. También es experto en FL Studio y te puede guiar para crear una canción desde cero.
 
+Para instalar las dependencias:
+
 ```
-python ar_tutorial.py --api-key TU_CLAVE             # Aprende nodos en Blender
+pip install openai opencv-python pyttsx3
+```
+
+El asistente lee cada instrucción en voz alta usando `pyttsx3`. Puedes desactivar la voz con la bandera `--mute`.
+
+```
+python ar_tutorial.py --api-key TU_CLAVE             # Aprende nodos en Blender con voz
+python ar_tutorial.py --api-key TU_CLAVE --mute      # Modo silencioso
 python ar_tutorial.py "FL Studio" --api-key TU_CLAVE             # Crea una canción desde cero
 python ar_tutorial.py "Nombre del Programa" --api-key TU_CLAVE  # Otro software
 ```


### PR DESCRIPTION
## Summary
- narrate tutorial steps with `pyttsx3` and optional `--mute` flag
- document voice feature, dependency and installation instructions in README
- avoid requiring `pyttsx3` when running with `--mute`

## Testing
- `python -m py_compile ar_tutorial.py`
- `python ar_tutorial.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68ae7600932083248cd55087ed5e3cd2